### PR TITLE
Entities

### DIFF
--- a/src/main/java/org/rahmasir/fmuserservice/converter/UserRoleConverter.java
+++ b/src/main/java/org/rahmasir/fmuserservice/converter/UserRoleConverter.java
@@ -1,0 +1,48 @@
+package org.rahmasir.fmuserservice.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.rahmasir.fmsharedlib.enums.UserRole;
+
+import java.util.stream.Stream;
+
+/**
+ * JPA Attribute Converter for the UserRole enum.
+ * This converter allows storing the enum as a string in the database
+ * and provides a centralized place for this logic.
+ */
+@Converter(autoApply = false) // Set to false to apply it only where explicitly declared with @Convert
+public class UserRoleConverter implements AttributeConverter<UserRole, String> {
+
+    /**
+     * Converts the UserRole enum to its string representation for database storage.
+     *
+     * @param role the enum value to be converted
+     * @return the string representation of the role, or null if the input is null
+     */
+    @Override
+    public String convertToDatabaseColumn(UserRole role) {
+        if (role == null) {
+            return null;
+        }
+        return role.name();
+    }
+
+    /**
+     * Converts the string from the database back to the UserRole enum.
+     *
+     * @param code the string value from the database
+     * @return the corresponding UserRole enum, or null if the input is null or invalid
+     */
+    @Override
+    public UserRole convertToEntityAttribute(String code) {
+        if (code == null) {
+            return null;
+        }
+
+        return Stream.of(UserRole.values())
+                .filter(c -> c.name().equals(code))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/entity/EmployerProfile.java
+++ b/src/main/java/org/rahmasir/fmuserservice/entity/EmployerProfile.java
@@ -1,0 +1,37 @@
+package org.rahmasir.fmuserservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * Contains profile information specific to a user with the EMPLOYER role.
+ */
+@Entity
+@Table(name = "employer_profile")
+@Getter
+@Setter
+@ToString(exclude = "user")
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+public class EmployerProfile {
+
+    @Id
+    private UUID id; // The primary key will be the same as the User's ID
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId // This maps the 'id' field as both primary key and foreign key
+    @JoinColumn(name = "id")
+    private User user;
+
+    @Column(nullable = false)
+    private String companyName;
+
+    private String bio;
+
+    public EmployerProfile(User user, String companyName) {
+        this.user = user;
+        this.companyName = companyName;
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/entity/FreelancerProfile.java
+++ b/src/main/java/org/rahmasir/fmuserservice/entity/FreelancerProfile.java
@@ -1,0 +1,54 @@
+package org.rahmasir.fmuserservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Contains profile information specific to a user with the FREELANCER role.
+ */
+@Entity
+@Table(name = "freelancer_profile")
+@Getter
+@Setter
+@ToString(exclude = "user")
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+public class FreelancerProfile {
+
+    @Id
+    private UUID id; // The primary key will be the same as the User's ID
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId // This maps the 'id' field as both primary key and foreign key
+    @JoinColumn(name = "id")
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String bio;
+
+    /**
+     * A many-to-many relationship with the Skill entity.
+     * FetchType.LAZY is used to prevent skills from being loaded automatically with the profile,
+     * which improves performance. They must be fetched explicitly when needed.
+     * CascadeType.PERSIST and MERGE are used so that if we add a new, unsaved Skill
+     * to a FreelancerProfile and save the profile, the new Skill will also be persisted.
+     */
+    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "freelancer_skill_association",
+            joinColumns = @JoinColumn(name = "freelancer_id"),
+            inverseJoinColumns = @JoinColumn(name = "skill_id")
+    )
+    private Set<Skill> skills = new HashSet<>();
+
+    public FreelancerProfile(User user, String name) {
+        this.user = user;
+        this.name = name;
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/entity/Skill.java
+++ b/src/main/java/org/rahmasir/fmuserservice/entity/Skill.java
@@ -1,0 +1,37 @@
+package org.rahmasir.fmuserservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Represents a unique skill that can be associated with freelancers or projects.
+ */
+@Entity
+@Table(name = "skill")
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(of = "name") // Skills are unique by name
+@NoArgsConstructor
+@AllArgsConstructor
+public class Skill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @ManyToMany(mappedBy = "skills")
+    @ToString.Exclude // Avoid circular dependency in toString
+    private Set<FreelancerProfile> freelancers = new HashSet<>();
+
+    public Skill(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/entity/User.java
+++ b/src/main/java/org/rahmasir/fmuserservice/entity/User.java
@@ -1,0 +1,90 @@
+package org.rahmasir.fmuserservice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.rahmasir.fmsharedlib.enums.UserRole;
+import org.rahmasir.fmuserservice.converter.UserRoleConverter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Represents a user in the system. This is the central entity for authentication
+ * and holds the common information for all user types.
+ */
+@Entity
+@Table(name = "app_user") // Using "app_user" as "user" is a reserved SQL keyword
+@Getter
+@Setter
+@ToString(exclude = {"freelancerProfile", "employerProfile"}) // Avoid circular dependency in toString
+@EqualsAndHashCode(of = "id") // Base equality on ID only
+@NoArgsConstructor
+public class User implements UserDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Convert(converter = UserRoleConverter.class)
+    @Column(nullable = false)
+    private UserRole role;
+
+    // One-to-one relationship with FreelancerProfile
+    // CascadeType.ALL ensures that if a User is deleted, their profile is also deleted.
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private FreelancerProfile freelancerProfile;
+
+    // One-to-one relationship with EmployerProfile
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private EmployerProfile employerProfile;
+
+    public User(String email, String password, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+    // --- UserDetails Implementation ---
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // The role is prefixed with "ROLE_" as per Spring Security's convention.
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        // We use email as the username for authentication.
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #3

I add 4 entity:
- User (just have email and password + id generated + role, that used for connecting to employer or freelancer profile)
- Employer profile (have company name and bio)
- Freelancer profile (have name and and bio and skills)
- skill (just a name + id generated): have a many to many relation with freelancer

we set cascade of many to many between freelancer and skill tables:
- persist: if a skill doesn't exist create automatically
- merge: if a freelancer updated its related skills are also updated

**NOTE**: also we use annotation of `@MapsId` in **freelancer** and **employer** for **user** field, this cause of equality of `user.id` and `freelancer.id` (or `employer.id`)
