### PR TITLE
Dtos

### DIFF
--- a/src/main/java/org/rahmasir/fmuserservice/dto/AuthRequest.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/AuthRequest.java
@@ -1,0 +1,20 @@
+package org.rahmasir.fmuserservice.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for user authentication (login).
+ *
+ * @param email    The user's email.
+ * @param password The user's password.
+ */
+public record AuthRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email should be valid")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        String password
+) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/EmployerProfileDto.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/EmployerProfileDto.java
@@ -1,0 +1,19 @@
+package org.rahmasir.userservice.dto;
+
+import java.util.UUID;
+
+/**
+ * DTO representing the public profile of an employer.
+ *
+ * @param id          The user's unique ID.
+ * @param email       The user's email.
+ * @param companyName The employer's company name.
+ * @param bio         The company's biography or description.
+ */
+public record EmployerProfileDto(
+        UUID id,
+        String email,
+        String companyName,
+        String bio
+) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/FreelancerProfileDto.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/FreelancerProfileDto.java
@@ -1,0 +1,22 @@
+package org.rahmasir.fmuserservice.dto;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * DTO representing the public profile of a freelancer.
+ *
+ * @param id     The user's unique ID.
+ * @param email  The user's email.
+ * @param name   The freelancer's name.
+ * @param bio    The freelancer's biography.
+ * @param skills A set of skills the freelancer possesses.
+ */
+public record FreelancerProfileDto(
+        UUID id,
+        String email,
+        String name,
+        String bio,
+        Set<SkillDto> skills
+) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/JwtAuthResponse.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/JwtAuthResponse.java
@@ -1,0 +1,9 @@
+package org.rahmasir.fmuserservice.dto;
+
+/**
+ * DTO for the response after a successful authentication
+ *
+ * @param accessToken The JWT access token
+ */
+public record JwtAuthResponse(String accessToken) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/RegisterRequest.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/RegisterRequest.java
@@ -1,0 +1,35 @@
+package org.rahmasir.fmuserservice.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.rahmasir.fmsharedlib.enums.UserRole;
+
+/**
+ * DTO for user registration. It captures all necessary information
+ * to create a new user and their initial profile.
+ *
+ * @param email       The user's email address. Must be a valid format.
+ * @param password    The user's password. Must be at least 8 characters long.
+ * @param role        The role of the user (FREELANCER or EMPLOYER).
+ * @param name        The freelancer's name (required if role is FREELANCER).
+ * @param companyName The employer's company name (required if role is EMPLOYER).
+ */
+public record RegisterRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email should be valid")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, message = "Password must be at least 8 characters long")
+        String password,
+
+        @NotNull(message = "User role is required")
+        UserRole role,
+
+        String name,
+
+        String companyName
+) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/SkillDto.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/SkillDto.java
@@ -1,0 +1,12 @@
+package org.rahmasir.fmuserservice.dto;
+
+import java.util.UUID;
+
+/**
+ * A simple DTO to represent a Skill.
+ *
+ * @param id   The unique identifier of the skill.
+ * @param name The name of the skill (e.g., "Java").
+ */
+public record SkillDto(UUID id, String name) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/UpdateEmployerProfileRequest.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/UpdateEmployerProfileRequest.java
@@ -1,0 +1,16 @@
+package org.rahmasir.fmuserservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for updating an employer's profile.
+ *
+ * @param companyName The employer's updated company name.
+ * @param bio         The company's updated biography.
+ */
+public record UpdateEmployerProfileRequest(
+        @NotBlank(message = "Company name cannot be blank")
+        String companyName,
+        String bio
+) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/dto/UpdateFreelancerProfileRequest.java
+++ b/src/main/java/org/rahmasir/fmuserservice/dto/UpdateFreelancerProfileRequest.java
@@ -1,0 +1,22 @@
+package org.rahmasir.fmuserservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.Set;
+
+/**
+ * DTO for updating a freelancer's profile.
+ *
+ * @param name   The freelancer's updated name.
+ * @param bio    The freelancer's updated biography.
+ * @param skills The complete, updated set of skill names for the freelancer.
+ */
+public record UpdateFreelancerProfileRequest(
+        @NotBlank(message = "Name cannot be blank")
+        String name,
+        String bio,
+        @NotEmpty(message = "Skills list cannot be empty")
+        Set<String> skills
+) {
+}


### PR DESCRIPTION
Closes #7

I create these DTOs:
- auth request: for login page, you should provide email (as username) and password
- register request: for register page, common between user types (employer and freelancer)
- jwt auth response: return an access token
- update employer profile request: for edit information
- update freelancer profile request: for edit information
- employer profile dto: just for represent
- freelancer profile dto: just for represent
- skill dto: just for represent (id and name)

also I use `Record` type for all dtos (because they are immutable)
