### PR TITLE
Security layer

### DIFF
--- a/src/main/java/org/rahmasir/fmuserservice/FmUserServiceApplication.java
+++ b/src/main/java/org/rahmasir/fmuserservice/FmUserServiceApplication.java
@@ -1,7 +1,9 @@
 package org.rahmasir.fmuserservice;
 
+import org.rahmasir.fmuserservice.config.properties.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 
 /**
@@ -10,6 +12,7 @@ import org.springframework.cache.annotation.EnableCaching;
  */
 @SpringBootApplication
 @EnableCaching // Enables Spring's caching abstraction
+@EnableConfigurationProperties(JwtProperties.class) // Enables our custom JWT properties
 public class FmUserServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/rahmasir/fmuserservice/config/SecurityConfig.java
+++ b/src/main/java/org/rahmasir/fmuserservice/config/SecurityConfig.java
@@ -1,0 +1,68 @@
+package org.rahmasir.fmuserservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.rahmasir.fmuserservice.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Main security configuration class for the application.
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity // Enables method-level security annotations like @PreAuthorize
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final UserDetailsService userDetailsService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // Disable CSRF as we are using stateless JWT authentication
+                .csrf(AbstractHttpConfigurer::disable)
+                // Define authorization rules for different endpoints
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/api-docs/**").permitAll()
+                        .anyRequest().authenticated())
+                // Configure session management to be stateless
+                .sessionManagement(manager -> manager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // Add our custom JWT authentication filter before the standard password authentication filter
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        var authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(this.userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/config/properties/JwtProperties.java
+++ b/src/main/java/org/rahmasir/fmuserservice/config/properties/JwtProperties.java
@@ -1,0 +1,14 @@
+package org.rahmasir.fmuserservice.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * A type-safe configuration properties record for JWT settings.
+ * This class maps properties prefixed with "jwt" from the application.yml file.
+ *
+ * @param secret       The secret key used for signing the JWT.
+ * @param expirationMs The expiration time for the JWT in milliseconds.
+ */
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(String secret, long expirationMs) {
+}

--- a/src/main/java/org/rahmasir/fmuserservice/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/rahmasir/fmuserservice/security/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package org.rahmasir.fmuserservice.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * A filter that runs once per request to handle JWT-based authentication.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String userEmail;
+
+        if (StringUtils.isEmpty(authHeader) || !StringUtils.startsWith(authHeader, "Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        jwt = authHeader.substring(7);
+        userEmail = jwtService.extractUsername(jwt);
+
+        if (StringUtils.isNotEmpty(userEmail) && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
+
+            if (jwtService.isTokenValid(jwt, userDetails)) {
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                var authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                context.setAuthentication(authToken);
+                SecurityContextHolder.setContext(context);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/security/JwtService.java
+++ b/src/main/java/org/rahmasir/fmuserservice/security/JwtService.java
@@ -1,0 +1,36 @@
+package org.rahmasir.fmuserservice.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Service interface for JSON Web Token (JWT) operations.
+ * Defines the contract for generating, validating, and extracting information from JWTs.
+ */
+public interface JwtService {
+
+    /**
+     * Extracts the username (email) from a given JWT.
+     *
+     * @param token The JWT string.
+     * @return The username contained within the token.
+     */
+    String extractUsername(String token);
+
+    /**
+     * Generates a new JWT for a given user.
+     *
+     * @param userDetails The user details for whom the token is to be generated.
+     * @return The generated JWT string.
+     */
+    String generateToken(UserDetails userDetails);
+
+    /**
+     * Checks if a given JWT is valid.
+     * A token is valid if it belongs to the user and has not expired.
+     *
+     * @param token       The JWT string.
+     * @param userDetails The user details to validate against.
+     * @return true if the token is valid, false otherwise.
+     */
+    boolean isTokenValid(String token, UserDetails userDetails);
+}

--- a/src/main/java/org/rahmasir/fmuserservice/security/impl/JwtServiceImpl.java
+++ b/src/main/java/org/rahmasir/fmuserservice/security/impl/JwtServiceImpl.java
@@ -1,0 +1,78 @@
+package org.rahmasir.fmuserservice.security.impl;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.rahmasir.fmuserservice.config.properties.JwtProperties;
+import org.rahmasir.fmuserservice.security.JwtService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Implementation of the JwtService interface.
+ */
+@Service
+@RequiredArgsConstructor
+public class JwtServiceImpl implements JwtService {
+
+    private final JwtProperties jwtProperties;
+
+    @Override
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    @Override
+    public String generateToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails);
+    }
+
+    @Override
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        final String username = extractUsername(token);
+        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    }
+
+    private <T> T extractClaim(String token, Function<Claims, T> claimsResolvers) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolvers.apply(claims);
+    }
+
+    private String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        return Jwts.builder()
+                .setClaims(extraClaims)
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.expirationMs()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser().setSigningKey(getSigningKey()).build().parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Key getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.secret());
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/org/rahmasir/fmuserservice/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/org/rahmasir/fmuserservice/service/impl/UserDetailsServiceImpl.java
@@ -1,0 +1,32 @@
+package org.rahmasir.fmuserservice.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.rahmasir.fmuserservice.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service to load user-specific data. It is used by Spring Security
+ * during the authentication process.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * Locates the user based on the username (in our case, email).
+     *
+     * @param username the username identifying the user whose data is required.
+     * @return a fully populated user record (never null).
+     * @throws UsernameNotFoundException if the user could not be found.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + username));
+    }
+}


### PR DESCRIPTION
Closes #13


This PR introduces **JWT-based authentication** to replace session-based security in the application. It adds a custom `JwtAuthenticationFilter` that intercepts each request, extracts and validates the JWT from the `Authorization` header, and sets the authenticated user in the `SecurityContextHolder`. The `JwtService` and its implementation handle token generation, extraction, and validation, while `UserDetailsServiceImpl` connects Spring Security to our database users. In `SecurityConfig`, we configure stateless session management, disable CSRF (since we no longer rely on cookies/sessions), expose beans for password encoding and authentication, and register the JWT filter before the standard authentication filter. With this setup, only whitelisted endpoints (auth & docs) are public, and all other routes require a valid JWT for access.
